### PR TITLE
Feature: Restart Application Action + Improve Keyboard Bindings

### DIFF
--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/ConfirmationDialog.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/ConfirmationDialog.cs
@@ -68,7 +68,26 @@ namespace AdrianMiasik.Components
             Close();
         }
 
-        public void Close()
+        public void Close(bool checkInterruptibility = false)
+        {
+            if (checkInterruptibility)
+            {
+                if (Timer.IsConfirmationDialogInterruptible())
+                {
+                    DestroyDialog();
+                }
+                else
+                {
+                    Debug.LogWarning("This confirmation dialog is not interruptible.");
+                }
+            }
+            else
+            {
+                DestroyDialog();
+            }
+        }
+
+        private void DestroyDialog()
         {
             Timer.ClearDialogPopup(this);
             Timer.GetTheme().Deregister(this); // Remove self from themed components

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Core/ThemeElement.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Core/ThemeElement.cs
@@ -17,7 +17,7 @@ namespace AdrianMiasik.Components.Core
             Timer = pomodoroTimer;
 
             // Register element to theme
-            pomodoroTimer.GetTheme().RegisterColorHook(this);
+            pomodoroTimer.GetTheme().Register(this);
             
             if (updateColors)
             {

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Core/ThemeElementToggle.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Core/ThemeElementToggle.cs
@@ -14,7 +14,7 @@ namespace AdrianMiasik.Components.Core
             Timer = pomodoroTimer;
 
             // Register element to theme
-            pomodoroTimer.GetTheme().RegisterColorHook(this);
+            pomodoroTimer.GetTheme().Register(this);
             
             // Update our components
             ColorUpdate(pomodoroTimer.GetTheme());

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/CreditsBubble.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/CreditsBubble.cs
@@ -45,7 +45,7 @@ namespace AdrianMiasik.Components
             fadeProgress = 1; // Starts at one since bubble is visible
             
             // Theme Element
-            timer.GetTheme().RegisterColorHook(this);
+            timer.GetTheme().Register(this);
             m_background.color = timer.GetTheme().GetCurrentColorScheme().m_backgroundHighlight;
             ColorUpdate(timer.GetTheme());
         }

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
@@ -65,7 +65,9 @@ namespace AdrianMiasik.Components
                     timer.GetTheme().DeregisterAllElements();
                     SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
                 }, null, 
-                    "This action will <color=red>reset all settings to their factory defaults.</color>");
+                    "This action will <color=red>reset all settings to their factory defaults.</color>", 
+                    null, 
+                    false);
             }
 
             // Tab between digits

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
@@ -45,7 +45,7 @@ namespace AdrianMiasik.Components
             }
             
             // Theme switch
-            if (Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKeyDown(KeyCode.Keypad1))
+            if (Input.GetKeyDown(KeyCode.T))
             {
                 timer.TriggerThemeSwitch();
             }
@@ -113,6 +113,15 @@ namespace AdrianMiasik.Components
                 else
                 {
                     timer.TriggerTimerRestart();
+                }
+            }
+            
+            // Theme switch
+            if (Input.GetKeyDown(KeyCode.U))
+            {
+                if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                {
+                    timer.TriggerThemeSwitch();
                 }
             }
             

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
@@ -71,31 +71,6 @@ namespace AdrianMiasik.Components
                     }
                 }
             }
-
-            if (Input.GetKeyDown(KeyCode.F1))
-            {
-                timer.TryChangeFormat(DigitFormat.SupportedFormats.SS);
-            }
-            
-            if (Input.GetKeyDown(KeyCode.F2))
-            {
-                timer.TryChangeFormat(DigitFormat.SupportedFormats.MM_SS);
-            }
-            
-            if (Input.GetKeyDown(KeyCode.F3))
-            {
-                timer.TryChangeFormat(DigitFormat.SupportedFormats.HH_MM_SS);
-            }
-            
-            if (Input.GetKeyDown(KeyCode.F4))
-            {
-                timer.TryChangeFormat(DigitFormat.SupportedFormats.HH_MM_SS_MS);
-            }
-            
-            if (Input.GetKeyDown(KeyCode.F5))
-            {
-                timer.TryChangeFormat(DigitFormat.SupportedFormats.DD_HH_MM_SS_MS);
-            }
         }
 
         /// <summary>
@@ -103,28 +78,55 @@ namespace AdrianMiasik.Components
         /// </summary>
         private void ProcessKeybinds()
         {
-            // Restart timer
+            // Restart timer / Switch timer mode
             if (Input.GetKeyDown(KeyCode.R))
             {
-                if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
-                {
-                    timer.TriggerTimerSwitch();
-                }
-                else
+                if (!IsUserHoldingControl())
                 {
                     timer.TriggerTimerRestart();
                 }
-            }
-            
-            // Theme switch
-            if (Input.GetKeyDown(KeyCode.U))
-            {
-                if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                else
                 {
-                    timer.TriggerThemeSwitch();
+                    timer.TriggerTimerSwitch();
                 }
             }
             
+            // Control modifier
+            if (IsUserHoldingControl())
+            {
+                // Switch theme
+                if (Input.GetKeyDown(KeyCode.U))
+                {
+                    timer.TriggerThemeSwitch();
+                }
+                
+                // Switch digit layouts
+                if (Input.GetKeyDown(KeyCode.F1))
+                {
+                    timer.TryChangeFormat(DigitFormat.SupportedFormats.SS);
+                }
+
+                if (Input.GetKeyDown(KeyCode.F2))
+                {
+                    timer.TryChangeFormat(DigitFormat.SupportedFormats.MM_SS);
+                }
+
+                if (Input.GetKeyDown(KeyCode.F3))
+                {
+                    timer.TryChangeFormat(DigitFormat.SupportedFormats.HH_MM_SS);
+                }
+
+                if (Input.GetKeyDown(KeyCode.F4))
+                {
+                    timer.TryChangeFormat(DigitFormat.SupportedFormats.HH_MM_SS_MS);
+                }
+
+                if (Input.GetKeyDown(KeyCode.F5))
+                {
+                    timer.TryChangeFormat(DigitFormat.SupportedFormats.DD_HH_MM_SS_MS);
+                }
+            }
+
             // Select All
             if (IsUserSelectingAll())
             {
@@ -142,6 +144,11 @@ namespace AdrianMiasik.Components
             {
                 timer.SetTimerValue(GUIUtility.systemCopyBuffer);
             }
+        }
+
+        private bool IsUserHoldingControl()
+        {
+            return Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
         }
 
         private bool IsUserSelectingAll()

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
@@ -60,8 +60,12 @@ namespace AdrianMiasik.Components
             // Restart application
             if (Input.GetKeyDown(KeyCode.F5))
             {
-                timer.GetTheme().DeregisterAllElements();
-                SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+                timer.SpawnConfirmationDialog(() =>
+                {
+                    timer.GetTheme().DeregisterAllElements();
+                    SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+                }, null, 
+                    "This action will <color=red>reset all settings to their factory defaults.</color>");
             }
 
             // Tab between digits

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/HotkeyDetector.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 namespace AdrianMiasik.Components
@@ -56,6 +57,13 @@ namespace AdrianMiasik.Components
                 timer.ClearSelection();
             }
             
+            // Restart application
+            if (Input.GetKeyDown(KeyCode.F5))
+            {
+                timer.GetTheme().DeregisterAllElements();
+                SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+            }
+
             // Tab between digits
             if (Input.GetKeyDown(KeyCode.Tab))
             {

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -101,6 +101,7 @@ namespace AdrianMiasik
         private bool muteSoundWhenOutOfFocus; // We want this to be true only for Windows platform due to UWP notifications
         // TODO: Move to dialog manager class
         private ConfirmationDialog currentDialogPopup;
+        private bool isCurrentDialogInterruptible = true;
         
         // Pulse Ring Complete Animation
         private float accumulatedRingPulseTime;
@@ -435,9 +436,9 @@ namespace AdrianMiasik
         {
             SwitchState(States.COMPLETE);
             
-            if (currentDialogPopup != null)
+            if (currentDialogPopup != null && isCurrentDialogInterruptible)
             {
-                currentDialogPopup.Close();
+                currentDialogPopup.Close(true);
             }
             
             // If timer completion was based on work/mode one timer
@@ -1035,13 +1036,19 @@ namespace AdrianMiasik
         }
 
         public void SpawnConfirmationDialog(Action onSubmit, Action onCancel = null, 
-            string topText = null, string bottomText = null)
+            string topText = null, string bottomText = null, bool interruptible = true)
         {
             if (currentDialogPopup != null)
                 return;
             
             currentDialogPopup = Instantiate(m_confirmationDialogPrefab, transform);
+            isCurrentDialogInterruptible = interruptible;
             currentDialogPopup.Initialize(this, onSubmit, onCancel, topText, bottomText);
+        }
+
+        public bool IsConfirmationDialogInterruptible()
+        {
+            return isCurrentDialogInterruptible;
         }
 
         public void ClearDialogPopup(ConfirmationDialog dialog)

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -136,6 +136,9 @@ namespace AdrianMiasik
         /// </summary>
         private void ConfigureSettings()
         {
+            // Set theme to light
+            GetTheme().m_darkMode = false;
+            
             // Set mute setting default
 #if UNITY_STANDALONE_OSX
             SetMuteSoundWhenOutOfFocus();
@@ -216,7 +219,7 @@ namespace AdrianMiasik
             PlaySpawnAnimation();
 
             // Setup & apply theme
-            m_theme.RegisterColorHook(this);
+            m_theme.Register(this);
             m_theme.ApplyColorChanges();
         }
         

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/ScriptableObjects/Theme.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/ScriptableObjects/Theme.cs
@@ -34,7 +34,7 @@ namespace AdrianMiasik.ScriptableObjects
             }
         }
 
-        public void RegisterColorHook(IColorHook hook)
+        public void Register(IColorHook hook)
         {
             if (colorElements.Contains(hook))
             {
@@ -52,6 +52,11 @@ namespace AdrianMiasik.ScriptableObjects
             {
                 colorElements.Remove(colorHook);
             }
+        }
+
+        public void DeregisterAllElements()
+        {
+            colorElements.Clear();
         }
 
         public ColorScheme GetCurrentColorScheme()

--- a/UnityPomodoro/UnityPomodoro.sln.DotSettings
+++ b/UnityPomodoro/UnityPomodoro.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UP/@EntryIndexedValue">UP</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=deregistered/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gameobject/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=interruptible/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Keybinds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pomodoros/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Squircle/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Rearranged our keyboard binds to something more appropriate. See table below / our [wiki page](https://github.com/adrian-miasik/unity-pomodoro/wiki/Keyboard-Controls) for most up to date bindings.

# Introducing 'Restart Application' Action
- Introduced new action `Restart Application` - Bound to `F5`
  - Note: This will wipe all settings to their factory defaults.
  - Confirmation dialogs invoked from the main class now have an "interruptible" parameter that can be utilized.

# Switch Theme Changes
- The following changes fixes #37 
  - The `T` key will be the new bind for changing the **T**heming or **T**oggling between light/dark mode.
  - And the Windows OS uses the following bind for accessibility `Windows + U`. So we'll modify that and use `Ctrl + U` as an alternative bind here too.

# Switch Digit Layout Changes
- The F keys to switch digit layouts now requires the `Ctrl` modifier to be held down.
  - This is because `F1` should be reserved for help, and `F5` should be reserved for refreshing / restarting the app

---

| Action                                    | Hotkey (< 1.7.0)   | Hotkey (>= 1.7.0) |
| ----------------------------------------- | ------------------- | ----------------- |
| Play / Pause Timer                        | `Spacebar`          | No changes        |
| Restart Timer                             | `R`                 | No changes        |
| Restart Application                       | N/A                 | `F5`              | 
| Switch Timer Mode (Work / Break)          | `Q` / `Ctrl + R`    | No changes        |
| Switch Theme (Light / Dark)               | `1` / `Numpad 1`    | `T` / `Ctrl + U`  |
| Switch Digit Layout to Full               | `F1`                | `Ctrl + F1`       |
| Switch Digit Layout to Detail             | `F2`                | `Ctrl + F2`       |
| Switch Digit Layout to Standard (Default) | `F3`                | `Ctrl + F3`       |
| Switch Digit Layout to Simple             | `F4`                | `Ctrl + F4`       |
| Switch Digit Layout to Bare               | `F5`                | `Ctrl + F5`       |
| Select All Digits                         | `Ctrl + A`          | No changes        |
| Copy                                      | `Ctrl + C`          | No changes        |
| Paste                                     | `Ctrl + V`          | No changes        |
| Cycle Through Digits                      | `Tab`               | No changes        |
| Select Next Digit                         | `Right Arrow`       | No changes        |
| Select Previous Digit                     | `Left Arrow`        | No changes        |
| Deselect Digit                            | `Escape`            | No changes        |
| Increment Digit                           | `Up Arrow`          | No changes        |
| Decrement Digit                           | `Down Arrow`        | No changes        |
| Delete / Clear Digit                      | `Delete` / `Return` | No changes        |
