### PR TITLE
Bugfix: Prevent Digits from Being Interactible When Switching Between Pages And Timer Is Running

### DIFF
--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -590,6 +590,11 @@ namespace AdrianMiasik
             m_digitFormat.GenerateFormat();
             m_digitFormat.ShowTime(TimeSpan.FromSeconds(currentTime)); // Update visuals to current time
             
+            if (m_state != States.SETUP)
+            {
+                m_digitFormat.Lock();
+            }
+            
             // Reset digit animation timings when opening/re-opening this page
             if (m_state == States.PAUSED)
             {


### PR DESCRIPTION
This was because we re-generated our digit format objects when switching pages, and the default state for the interactibility for DoubleDigit.Interactibilty is set to True. We need to make sure to lock them unless, the user's timer is in the SETUP state.

This PR fixes #40 