### PR TITLE
Improvement: Replace Unity Analytics Service Toggle Workaround

### DIFF
--- a/UnityPomodoro/Assembly-CSharp-Editor.csproj
+++ b/UnityPomodoro/Assembly-CSharp-Editor.csproj
@@ -334,7 +334,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="nunit.framework">
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.ext.nunit@1.0.6\net35\unity-custom\nunit.framework.dll</HintPath>

--- a/UnityPomodoro/Assembly-CSharp.csproj
+++ b/UnityPomodoro/Assembly-CSharp.csproj
@@ -383,7 +383,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="UnityEditor.iOS.Extensions.Xcode">
      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.1f1\Editor\Data\PlaybackEngines\iOSSupport\UnityEditor.iOS.Extensions.Xcode.dll</HintPath>

--- a/UnityPomodoro/LeTai.TranslucentImage.Editor.csproj
+++ b/UnityPomodoro/LeTai.TranslucentImage.Editor.csproj
@@ -334,7 +334,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="nunit.framework">
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.ext.nunit@1.0.6\net35\unity-custom\nunit.framework.dll</HintPath>

--- a/UnityPomodoro/LeTai.TranslucentImage.UniversalRP.csproj
+++ b/UnityPomodoro/LeTai.TranslucentImage.UniversalRP.csproj
@@ -332,7 +332,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="UnityEditor.iOS.Extensions.Xcode">
      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.1f1\Editor\Data\PlaybackEngines\iOSSupport\UnityEditor.iOS.Extensions.Xcode.dll</HintPath>

--- a/UnityPomodoro/LeTai.TranslucentImage.csproj
+++ b/UnityPomodoro/LeTai.TranslucentImage.csproj
@@ -343,7 +343,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="UnityEditor.iOS.Extensions.Xcode">
      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.1f1\Editor\Data\PlaybackEngines\iOSSupport\UnityEditor.iOS.Extensions.Xcode.dll</HintPath>

--- a/UnityPomodoro/Packages/manifest.json
+++ b/UnityPomodoro/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.mobile.notifications": "2.0.0",
     "com.unity.recorder": "3.0.3",
     "com.unity.render-pipelines.universal": "12.1.6",
-    "com.unity.services.analytics": "3.0.0-pre.3",
+    "com.unity.services.analytics": "4.0.0-pre.2",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.ugui": "1.0.0",

--- a/UnityPomodoro/Packages/packages-lock.json
+++ b/UnityPomodoro/Packages/packages-lock.json
@@ -55,8 +55,8 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
-      "version": "2.0.0",
-      "depth": 3,
+      "version": "3.0.1",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -99,31 +99,23 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.analytics": {
-      "version": "3.0.0-pre.3",
+      "version": "4.0.0-pre.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.services.analytics-runtime": "2.0.0-pre.3",
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.services.analytics-runtime": {
-      "version": "2.0.0-pre.3",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.services.core": "1.1.0-pre.41"
+        "com.unity.ugui": "1.0.0",
+        "com.unity.services.core": "1.2.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.services.core": {
-      "version": "1.1.0-pre.41",
-      "depth": 2,
+      "version": "1.2.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.nuget.newtonsoft-json": "2.0.0"
+        "com.unity.nuget.newtonsoft-json": "3.0.1",
+        "com.unity.modules.androidjni": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },

--- a/UnityPomodoro/ProjectSettings/RiderScriptEditorPersistedState.asset
+++ b/UnityPomodoro/ProjectSettings/RiderScriptEditorPersistedState.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Rider.Editor:Packages.Rider.Editor:RiderScriptEditorPersistedState
+  lastWriteTicks: -8585499808458042775


### PR DESCRIPTION
It seems like as of [Unity Analytics - Version 4.0](https://docs.unity3d.com/Packages/com.unity.services.analytics@4.0/changelog/CHANGELOG.html#new-features), we can now enable/disable the service at runtime:
- `Added ability to disable and re-enable the Analytics SDK`

How this wasn't available before still boggles my mind...but beta is beta.

Currently our workaround prior to this change was to not start the service on launch. And when a user did disable the analytics via the settings panel, we would restart the application and not start it up on restart/re-launch. It seems that with this new change, user's won't have to restart the application to enable or disable the service anymore. 

So with this change we can now remove our implemented workaround.
