### PR TITLE
Improvement: Replace Unity Analytics Service Toggle Workaround

### DIFF
--- a/UnityPomodoro/Assembly-CSharp-Editor.csproj
+++ b/UnityPomodoro/Assembly-CSharp-Editor.csproj
@@ -334,7 +334,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="nunit.framework">
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.ext.nunit@1.0.6\net35\unity-custom\nunit.framework.dll</HintPath>

--- a/UnityPomodoro/Assembly-CSharp.csproj
+++ b/UnityPomodoro/Assembly-CSharp.csproj
@@ -383,7 +383,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="UnityEditor.iOS.Extensions.Xcode">
      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.1f1\Editor\Data\PlaybackEngines\iOSSupport\UnityEditor.iOS.Extensions.Xcode.dll</HintPath>

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Specific/Settings/OptionUnityAnalytics.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Specific/Settings/OptionUnityAnalytics.cs
@@ -36,14 +36,6 @@ namespace AdrianMiasik.Components.Specific.Settings
         {
             if (!state)
             {
-                // Send disabled event log
-                Dictionary<string, object> parameters = new Dictionary<string, object>()
-                {
-                    { "testingKey", "testingValue123Disabled" },
-                };
-                Events.CustomData("analyticsDisabled", parameters);
-                Events.Flush();
-                    
                 // Disable analytics
                 Timer.ToggleUnityAnalytics(false, false);
             }

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Specific/Settings/OptionUnityAnalytics.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Specific/Settings/OptionUnityAnalytics.cs
@@ -36,49 +36,20 @@ namespace AdrianMiasik.Components.Specific.Settings
         {
             if (!state)
             {
-                Timer.GetConfirmDialogManager().SpawnConfirmationDialog(() =>
+                // Send disabled event log
+                Dictionary<string, object> parameters = new Dictionary<string, object>()
                 {
-                    // Send disabled event log
-                    Dictionary<string, object> parameters = new Dictionary<string, object>()
-                    {
-                        { "testingKey", "testingValue123Disabled" },
-                    };
-                    Events.CustomData("analyticsDisabled", parameters);
-                    Events.Flush();
+                    { "testingKey", "testingValue123Disabled" },
+                };
+                Events.CustomData("analyticsDisabled", parameters);
+                Events.Flush();
                     
-                    // Disable analytics
-                    Timer.ToggleUnityAnalytics(false, false);
-#if UNITY_ANALYTICS_EVENT_LOGS
-                    Debug.LogWarning("Unity Analytics - Restarting Application with Disabled Analytics.");
-#endif
-                    
-#if UNITY_EDITOR
-                    UnityEditor.EditorApplication.ExitPlaymode();
-#elif UNITY_ANDROID
-                    RestartAndroidProcess();
-#else
-                    // Windows + (hopefully mac and linux too... TODO: Device testing)
-                    System.Diagnostics.Process.Start(Application.dataPath.Replace("_Data", ".exe"));
-                    Application.Quit();
-#endif
-                }, () =>
-                {
-                    // Cancel visuals if they don't agree
-                    m_toggleSlider.Refresh(true);
-                    
-                    // Edge condition: If playing in editor and tweaking values via inspector...
-#if UNITY_EDITOR
-                    if (Application.isPlaying)
-                    {
-                        // Apply and save
-                        Timer.GetSystemSettings().m_enableUnityAnalytics = true;
-                        UserSettingsSerializer.SaveSystemSettings(Timer.GetSystemSettings());
-                    }
-#endif
-                }, "Disabling 'Unity Analytics' requires a restart.", "");
+                // Disable analytics
+                Timer.ToggleUnityAnalytics(false, false);
             }
             else
             {
+                // Enable analytics
                 Timer.ToggleUnityAnalytics(true, false);
             }
         }

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -323,11 +323,10 @@ namespace AdrianMiasik
                 PerformanceReporting.enabled = false;
                 Analytics.limitUserTracking = true;
                 Analytics.deviceStatsEnabled = false;
+                AnalyticsService.Instance.SetAnalyticsEnabled(false);
 
 #if UNITY_ANALYTICS_EVENT_LOGS
-                Debug.LogWarning("Unity Analytics - Stopped Service. " +
-                                 "(Service will still cache some events into it's buffer it seems, but won't upload " +
-                                 "them.)");
+                Debug.LogWarning("Unity Analytics - Stopped Service.");
 #endif
             }
         }
@@ -340,11 +339,8 @@ namespace AdrianMiasik
         {
             try
             {
-                // Debug.LogWarning("Unity Analytics - Starting Up Service...");
-                
                 await UnityServices.InitializeAsync();
-                List<string> consentIdentifiers = await AnalyticsService.Instance.CheckForRequiredConsents();
-                
+
 #if UNITY_ANALYTICS_EVENT_LOGS
                 Debug.LogWarning("Unity Analytics - Service Started.");
 #endif
@@ -354,6 +350,7 @@ namespace AdrianMiasik
                 PerformanceReporting.enabled = true;
                 Analytics.limitUserTracking = false;
                 Analytics.deviceStatsEnabled = true;
+                await AnalyticsService.Instance.SetAnalyticsEnabled(true);
 
                 if (isBootingUp)
                 {

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -318,6 +318,14 @@ namespace AdrianMiasik
             }
             else
             {
+                // Send disabled event log
+                Dictionary<string, object> parameters = new Dictionary<string, object>()
+                {
+                    { "testingKey", "testingValue1234Disabled" },
+                };
+                AnalyticsService.Instance.CustomData("analyticsServiceDisabled", parameters);
+                AnalyticsService.Instance.Flush();
+
                 // Disable analytics
                 Analytics.enabled = false;
                 PerformanceReporting.enabled = false;
@@ -357,20 +365,20 @@ namespace AdrianMiasik
                     // Send enabled event log
                     Dictionary<string, object> parameters = new Dictionary<string, object>()
                     {
-                        { "testingKey", "testingValue123Init" },
+                        { "testingKey", "testingValue1234Init" },
                     };
-                    Events.CustomData("analyticsInitialized", parameters);
-                    Events.Flush();
+                    AnalyticsService.Instance.CustomData("analyticsServiceInitialized", parameters);
+                    AnalyticsService.Instance.Flush();
                 }
                 else
                 {
                     // Send enabled event log
                     Dictionary<string, object> parameters = new Dictionary<string, object>()
                     {
-                        { "testingKey", "testingValue123Enabled" },
+                        { "testingKey", "testingValue1234Enabled" },
                     };
-                    Events.CustomData("analyticsEnabled", parameters);
-                    Events.Flush();
+                    AnalyticsService.Instance.CustomData("analyticsServiceEnabled", parameters);
+                    AnalyticsService.Instance.Flush();
                 }
             }
             catch (ConsentCheckException e)

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -343,7 +343,7 @@ namespace AdrianMiasik
                 // Debug.LogWarning("Unity Analytics - Starting Up Service...");
                 
                 await UnityServices.InitializeAsync();
-                List<string> consentIdentifiers = await Events.CheckForRequiredConsents();
+                List<string> consentIdentifiers = await AnalyticsService.Instance.CheckForRequiredConsents();
                 
 #if UNITY_ANALYTICS_EVENT_LOGS
                 Debug.LogWarning("Unity Analytics - Service Started.");

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -314,7 +314,7 @@ namespace AdrianMiasik
             if (enableUnityAnalytics)
             {
                 // Enable analytics
-                StartServices(isBootingUp);
+                StartAnalyticsService(isBootingUp);
             }
             else
             {
@@ -335,7 +335,7 @@ namespace AdrianMiasik
         /// Starts up our Unity Analytics service.
         /// </summary>
         /// <param name="isBootingUp"></param>
-        async void StartServices(bool isBootingUp)
+        async void StartAnalyticsService(bool isBootingUp)
         {
             try
             {

--- a/UnityPomodoro/LeTai.TranslucentImage.Editor.csproj
+++ b/UnityPomodoro/LeTai.TranslucentImage.Editor.csproj
@@ -334,7 +334,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="nunit.framework">
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.ext.nunit@1.0.6\net35\unity-custom\nunit.framework.dll</HintPath>

--- a/UnityPomodoro/LeTai.TranslucentImage.UniversalRP.csproj
+++ b/UnityPomodoro/LeTai.TranslucentImage.UniversalRP.csproj
@@ -332,7 +332,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="UnityEditor.iOS.Extensions.Xcode">
      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.1f1\Editor\Data\PlaybackEngines\iOSSupport\UnityEditor.iOS.Extensions.Xcode.dll</HintPath>

--- a/UnityPomodoro/LeTai.TranslucentImage.csproj
+++ b/UnityPomodoro/LeTai.TranslucentImage.csproj
@@ -343,7 +343,7 @@
      <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.burst@1.6.5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll</HintPath>
      </Reference>
      <Reference Include="Newtonsoft.Json">
-     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@2.0.0\Runtime\Newtonsoft.Json.dll</HintPath>
+     <HintPath>C:\Users\User\Documents\git-repositories\unity-pomodoro\UnityPomodoro\Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.1\Runtime\Newtonsoft.Json.dll</HintPath>
      </Reference>
      <Reference Include="UnityEditor.iOS.Extensions.Xcode">
      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.1f1\Editor\Data\PlaybackEngines\iOSSupport\UnityEditor.iOS.Extensions.Xcode.dll</HintPath>

--- a/UnityPomodoro/Packages/manifest.json
+++ b/UnityPomodoro/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.mobile.notifications": "2.0.0",
     "com.unity.recorder": "3.0.3",
     "com.unity.render-pipelines.universal": "12.1.6",
-    "com.unity.services.analytics": "3.0.0-pre.3",
+    "com.unity.services.analytics": "4.0.0-pre.2",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.ugui": "1.0.0",

--- a/UnityPomodoro/Packages/packages-lock.json
+++ b/UnityPomodoro/Packages/packages-lock.json
@@ -55,8 +55,8 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
-      "version": "2.0.0",
-      "depth": 3,
+      "version": "3.0.1",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -99,31 +99,23 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.analytics": {
-      "version": "3.0.0-pre.3",
+      "version": "4.0.0-pre.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.services.analytics-runtime": "2.0.0-pre.3",
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.services.analytics-runtime": {
-      "version": "2.0.0-pre.3",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.services.core": "1.1.0-pre.41"
+        "com.unity.ugui": "1.0.0",
+        "com.unity.services.core": "1.2.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.services.core": {
-      "version": "1.1.0-pre.41",
-      "depth": 2,
+      "version": "1.2.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.nuget.newtonsoft-json": "2.0.0"
+        "com.unity.nuget.newtonsoft-json": "3.0.1",
+        "com.unity.modules.androidjni": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },

--- a/UnityPomodoro/ProjectSettings/RiderScriptEditorPersistedState.asset
+++ b/UnityPomodoro/ProjectSettings/RiderScriptEditorPersistedState.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Rider.Editor:Packages.Rider.Editor:RiderScriptEditorPersistedState
+  lastWriteTicks: -8585499808458042775


### PR DESCRIPTION
It seems like as of [Unity Analytics - Version 4.0](https://docs.unity3d.com/Packages/com.unity.services.analytics@4.0/changelog/CHANGELOG.html#new-features), we can now enable/disable the service at runtime:
- `Added ability to disable and re-enable the Analytics SDK`

How this wasn't available before still boggles my mind...but beta is beta.

Currently our workaround prior to this change was to not start the service on launch. And when a user did disable the analytics via the settings panel, we would restart the application and not start it up on restart/re-launch. It seems that with this new change, user's won't have to restart the application to enable or disable the service anymore. 

So we can now remove our implemented workaround and toggle the service at run-time.
