### PR TITLE
Bugfix: Force Refresh Timer Values On Page Switch

### DIFF
--- a/UnityPomodoro/Assets/AdrianMiasik/Scenes/Main.unity
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scenes/Main.unity
@@ -548,6 +548,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_title: {fileID: 0}
+  m_format: {fileID: 1015735896}
 --- !u!1 &61516144
 GameObject:
   m_ObjectHideFlags: 0
@@ -2037,7 +2038,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 489833435901344923, guid: 88cf29bd208ddcf4ca1a76e1dd21e99c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 19.400856
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 489833435901344923, guid: 88cf29bd208ddcf4ca1a76e1dd21e99c, type: 3}
       propertyPath: m_SizeDelta.y
@@ -2792,7 +2793,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 489833435901344923, guid: 88cf29bd208ddcf4ca1a76e1dd21e99c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 19.400856
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 489833435901344923, guid: 88cf29bd208ddcf4ca1a76e1dd21e99c, type: 3}
       propertyPath: m_SizeDelta.y
@@ -5013,7 +5014,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36.05
+  m_fontSize: 27
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -5612,7 +5613,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 489833435901344923, guid: 88cf29bd208ddcf4ca1a76e1dd21e99c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 19.400856
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 489833435901344923, guid: 88cf29bd208ddcf4ca1a76e1dd21e99c, type: 3}
       propertyPath: m_SizeDelta.y
@@ -6488,7 +6489,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 21.35
+  m_fontSize: 16.8
   m_fontSizeBase: 10.07
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -8512,7 +8513,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 489833435901344923, guid: 88cf29bd208ddcf4ca1a76e1dd21e99c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 19.400856
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 489833435901344923, guid: 88cf29bd208ddcf4ca1a76e1dd21e99c, type: 3}
       propertyPath: m_SizeDelta.y
@@ -9573,7 +9574,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -2.4997253, y: 2.5}
+  m_AnchoredPosition: {x: -2.4997559, y: 2.5}
   m_SizeDelta: {x: -25, y: -25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1535463478 stripped
@@ -11242,7 +11243,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 10.35
+  m_fontSize: 8.15
   m_fontSizeBase: 9
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -14216,7 +14217,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 2, y: 1}
-  m_AnchoredPosition: {x: 8.000009, y: 0}
+  m_AnchoredPosition: {x: 8.000008, y: 0}
   m_SizeDelta: {x: 0, y: -4}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!1 &7149234586048015815

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Specific/Pages/SidebarPages.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Specific/Pages/SidebarPages.cs
@@ -50,6 +50,11 @@ namespace AdrianMiasik.Components.Specific.Pages
             Select(m_aboutPage);
         }
 
+        public void RefreshTimerPage()
+        {
+            m_timerPage.Refresh();
+        }
+        
         public void RefreshSettingsPage()
         {
             m_settingsPage.Refresh();

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Specific/Pages/TimerPage.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/Components/Specific/Pages/TimerPage.cs
@@ -1,10 +1,20 @@
 ﻿using AdrianMiasik.Components.Base;
+using AdrianMiasik.Components.Core.Containers;
 using AdrianMiasik.ScriptableObjects;
+using UnityEngine;
 
 namespace AdrianMiasik.Components.Specific.Pages
 {
     public class TimerPage: Page
     {
+        [SerializeField] private DigitFormat m_format;
+
+        public override void Refresh()
+        {
+            base.Refresh();
+            m_format.RefreshDigitVisuals();
+        }
+
         public override void ColorUpdate(Theme theme)
         {
             // No title

--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -869,6 +869,8 @@ namespace AdrianMiasik
             {
                 ResetDigitFadeAnim();
             }
+            
+            m_sidebarPages.RefreshTimerPage();
         }
         
         public void ShowSettings()


### PR DESCRIPTION
- Fixes #80 
- When we switch back to the page format, we then generate our digit format. After digit format generation we force a digit value refresh to get the correct visuals.