### PR TITLE
 Editor Feature: Unity Cloud Builds Renamer

### DIFF
--- a/UnityPomodoro/Assets/AdrianMiasik/Editor/CloudBuildRenamer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Editor/CloudBuildRenamer.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace AdrianMiasik.Editor
+{
+    public class CloudBuildRenamer : EditorWindow
+    {
+        [SerializeField] private VisualTreeAsset uxmlTree;
+
+        private TextField unityCloudBuildsDirectoryTextField;
+        private string unityCloudBuildsDirectory;
+        
+        [MenuItem("Window/UI Toolkit/CloudBuildRenamer")]
+        public static void ShowExample()
+        {
+            CloudBuildRenamer wnd = GetWindow<CloudBuildRenamer>();
+            wnd.titleContent = new GUIContent("Cloud Build Renamer");
+        }
+
+        public void CreateGUI()
+        {
+            // Each editor window contains a root VisualElement object
+            VisualElement root = rootVisualElement;
+            
+            // Import UXML
+            rootVisualElement.Add(uxmlTree.Instantiate());
+
+            // Cache text field
+            TextField ucbDirectoryField = rootVisualElement.Q<TextField>("unity-cloud-build-dir");
+            unityCloudBuildsDirectoryTextField = ucbDirectoryField;
+
+            // Hook up browse button on click
+            VisualElement browseButton = rootVisualElement.Q<Button>("browse-button");
+            browseButton.RegisterCallback<ClickEvent>(BrowseButtonOnClick);
+            
+            // Hook up rename button on click
+            VisualElement renameButton = rootVisualElement.Q<Button>("rename-button");
+            renameButton.RegisterCallback<ClickEvent>(RenameButtonOnClick);
+        }
+        
+        /// <summary>
+        /// Invoked when the browse button is pressed/clicked.
+        /// </summary>
+        /// <param name="evt"></param>
+        private void BrowseButtonOnClick(ClickEvent evt)
+        {
+            unityCloudBuildsDirectory = EditorUtility.OpenFolderPanel("Unity Cloud Builds Directory", "", "");
+            unityCloudBuildsDirectoryTextField.SetValueWithoutNotify(unityCloudBuildsDirectory);
+        }
+        
+        /// <summary>
+        /// Invoked when the rename button is pressed/clicked.
+        /// </summary>
+        /// <param name="evt"></param>
+        private void RenameButtonOnClick(ClickEvent evt)
+        {
+            int numberOfFilesRenamed = 0;
+            
+            if (!string.IsNullOrEmpty(unityCloudBuildsDirectory))
+            {
+                Debug.Log("Executing UCB rename on path: " + unityCloudBuildsDirectory);
+                
+                // Fetch zip files
+                string[] files = Directory
+                    .EnumerateFiles(unityCloudBuildsDirectory, "*.*")
+                    .Where(file => file.ToLower().EndsWith("zip"))
+                    .ToArray();
+                
+                foreach (string s in files)
+                {
+                    // Copy path
+                    string correctedName = s;
+                    
+                    // Remove .zip extension
+                    correctedName = correctedName.Replace(".zip", "");
+                    
+                    // Remove username
+                    correctedName = correctedName.Replace("adrian-miasik-", "");
+
+                    // Replace 'default' keyword with version number
+                    correctedName = correctedName.Replace("default", Application.version);
+
+                    // Remove trailing digits
+                    char[] digits = new[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
+                    correctedName = correctedName.TrimEnd(digits);
+                    
+                    // If we have a single trailing 'space' after our digit trim...
+                    if (correctedName[^1].CompareTo('-') == 0)
+                    {
+                        // Remove extra trailing 'space'
+                        correctedName = correctedName.TrimEnd('-');
+                    }
+                    
+                    // Re-add extension
+                    correctedName += ".zip";
+
+                    if (s != correctedName)
+                    {
+                        Debug.Log("Renaming: '" +  s + "' to '" + correctedName + "'.");
+                        File.Move(s, correctedName);
+                        numberOfFilesRenamed++;
+                    }
+                }
+
+                if (numberOfFilesRenamed > 0)
+                {
+                    Debug.Log("Unity Cloud Builds have been renamed successfully! (" + numberOfFilesRenamed 
+                        + ")");
+                }
+                else
+                {
+                    Debug.LogWarning("No Unity Cloud Build naming conventions found.");
+                }
+            }
+            else
+            {
+                Debug.LogWarning("No asset path provided!");
+            }
+        }
+    }
+}

--- a/UnityPomodoro/Assets/AdrianMiasik/Editor/CloudBuildRenamer.cs.meta
+++ b/UnityPomodoro/Assets/AdrianMiasik/Editor/CloudBuildRenamer.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: ee88e7a0e2ad1f542a7ba3a505ca49fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - m_ViewDataDictionary: {instanceID: 0}
+  - uxmlTree: {fileID: 9197481963319205126, guid: 0250a4acd7de34c4c8776130aec3b1c5, type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityPomodoro/Assets/AdrianMiasik/Editor/CloudBuildRenamerUXML.uxml
+++ b/UnityPomodoro/Assets/AdrianMiasik/Editor/CloudBuildRenamerUXML.uxml
@@ -1,0 +1,6 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="False">
+    <ui:TextField picking-mode="Ignore" label="Unity Cloud Builds Directory: " name="unity-cloud-build-dir" style="visibility: visible;">
+        <ui:Button text="Browse..." display-tooltip-when-elided="true" name="browse-button" style="white-space: nowrap;" />
+    </ui:TextField>
+    <ui:Button text="Rename Builds" display-tooltip-when-elided="true" name="rename-button" style="left: auto; -unity-text-align: middle-center; white-space: nowrap;" />
+</ui:UXML>

--- a/UnityPomodoro/Assets/AdrianMiasik/Editor/CloudBuildRenamerUXML.uxml.meta
+++ b/UnityPomodoro/Assets/AdrianMiasik/Editor/CloudBuildRenamerUXML.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 0250a4acd7de34c4c8776130aec3b1c5
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
# General
Instead of renaming downloaded Unity cloud builds manually, I wrote up this nifty custom editor window that can automate the process for us. This tool will remove our author name from the string, replace the 'default' keyword with the application version, and remove the trailing build number.

# Example
`adrian-miasik-unity-pomodoro-default-windows-desktop-64-bit-56.zip` gets renamed to -> `unity-pomodoro-2.2.0-windows-desktop-64-bit.zip`

# How To Use
1. Simple open the project with the intended version number.
2. `Window` > `UI Toolkit` > `CloudBuildRenamer`
3. Press `Browse...`
4. Specify the directory where your Unity cloud build downloads are at.
5. Press `Rename Builds`
6. Done! (See console for output)