### PR TITLE
Bugfix: Prevent paused digits from resetting to starting values on page refresh

### DIFF
--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -878,8 +878,10 @@ namespace AdrianMiasik
             {
                 ResetDigitFadeAnim();
             }
-            
-            m_sidebarPages.RefreshTimerPage();
+            else
+            {
+                m_sidebarPages.RefreshTimerPage();
+            }
         }
         
         public void ShowSettings()


### PR DESCRIPTION
This PR fixes issue #92.

In the past while we were fixing issue #80, we've solved most cases where the timer values were not updating properly on page changes. However we did not account for the timer being in the paused state. (Which is why #92 was opened)

Meaning when the timer is paused, we are forcing the timer to reset visually back to it's starting values on page refreshes (hiding the pause time). This is not the intention since we don't want to reset the paused timings to the starting values on page refreshes.

So now with this PR, when selecting the same page we are currently on, we will only refresh the timer back to it's starting values if the timer isn't in the paused state. Meaning the paused state will not refresh on page changes but instead retain its current values.