### PR TITLE
Bugfix: Prevent background process from running at an uncapped framerate resulting in unnecessary GPU usage

### DIFF
--- a/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
+++ b/UnityPomodoro/Assets/AdrianMiasik/Scripts/PomodoroTimer.cs
@@ -185,7 +185,7 @@ namespace AdrianMiasik
                 focusLossTime = DateTime.Now.TimeOfDay;
 #endif
                 
-                Application.targetFrameRate = 0;
+                Application.targetFrameRate = 15;
             }
             else
             {

--- a/UnityPomodoro/ProjectSettings/QualitySettings.asset
+++ b/UnityPomodoro/ProjectSettings/QualitySettings.asset
@@ -4,7 +4,7 @@
 QualitySettings:
   m_ObjectHideFlags: 0
   serializedVersion: 5
-  m_CurrentQuality: 3
+  m_CurrentQuality: 0
   m_QualitySettings:
   - serializedVersion: 2
     name: Low
@@ -62,7 +62,7 @@ QualitySettings:
     softVegetation: 0
     realtimeReflectionProbes: 0
     billboardsFaceCameraPosition: 0
-    vSyncCount: 1
+    vSyncCount: 0
     lodBias: 0.7
     maximumLODLevel: 0
     streamingMipmapsActive: 0
@@ -98,7 +98,7 @@ QualitySettings:
     softVegetation: 1
     realtimeReflectionProbes: 1
     billboardsFaceCameraPosition: 1
-    vSyncCount: 1
+    vSyncCount: 0
     lodBias: 1
     maximumLODLevel: 0
     streamingMipmapsActive: 0
@@ -129,7 +129,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 0
+    antiAliasing: 4
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1
@@ -148,13 +148,14 @@ QualitySettings:
     asyncUploadBufferSize: 16
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
-    customRenderPipeline: {fileID: 11400000, guid: d847b876476d3d6468f5dfcd34266f96, type: 2}
+    customRenderPipeline: {fileID: 11400000, guid: df8793fdb205bd3479efa3df9d8e100f, type: 2}
     excludedTargetPlatforms: []
   m_PerPlatformDefaultQuality:
     Android: 1
     Lumin: 2
     Nintendo Switch: 2
     PS4: 2
+    Server: 0
     Stadia: 2
     Standalone: 3
     WebGL: 1


### PR DESCRIPTION
Fixes #96 

- Sets the background process framerate to 15 FPS/Hz
- Disabled v-sync on quality presets
- Fix URP ultra quality preset reference